### PR TITLE
lib/database.rb : prise en compte DB_PATH comme chemin complet de la base

### DIFF
--- a/fake_editor_app/lib/database.rb
+++ b/fake_editor_app/lib/database.rb
@@ -5,9 +5,7 @@ require 'fileutils'
 
 # Initialize database connection with proper path resolution
 db_dir = File.expand_path('..', __dir__)
-db_path = File.join(db_dir, ENV.fetch('DB_PATH', 'fake_editor.db'))
-# Ensure directory exists and is writable
-FileUtils.mkdir_p(db_dir)
+db_path = ENV['DB_PATH'] || File.join(db_dir, 'fake_editor.db')
 
 # Initialize SQLite connection
 DB = Sequel.sqlite(db_path)


### PR DESCRIPTION
Sans ça, la spécification de `DB_PATH` restait relative à `db_dir` et empêchait de spécifier un chemin absolu pour la base de données.

J'enlève aussi le `mkdir_p`, je pense pas que ce soit à l'application de créer des répertoires, d'autant plus qu'on peut être dans un cas de figure où le répertoire existe déjà avec des droits restreints par le système, ce qui pourrait faire échouer `mkdir_p` alors que le fichier de base serait quand même lisible (selon les droits des répertoires parents).