### PR TITLE
Cleaning: Ux / UI fix

### DIFF
--- a/app/javascript/controllers/input_validation_controller.js
+++ b/app/javascript/controllers/input_validation_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "submitButton"]
+
+  connect() {
+    this._updateSubmitButtonState()
+  }
+
+  validateInput() {
+    this._updateSubmitButtonState()
+  }
+
+  _updateSubmitButtonState() {
+    const hasValidInput = this.inputTargets.some(input => {
+      const value = input.value.trim()
+      return value.length > 0
+    })
+    
+    if (hasValidInput) {
+      this._enableSubmit()
+    } else {
+      this._disableSubmit()
+    }
+  }
+
+  _enableSubmit() {
+    this.submitButtonTarget.disabled = false
+  }
+
+  _disableSubmit() {
+    this.submitButtonTarget.disabled = true
+  }
+}

--- a/app/views/buyer/public_markets/summary.html.erb
+++ b/app/views/buyer/public_markets/summary.html.erb
@@ -103,7 +103,7 @@
           <% end %>
           
           <% if optional_fields.any? %>
-            <h2 class="fr-h2 fr-mb-3w" style="color: var(--background-action-high-blue-france);">2. <%= t('buyer.public_markets.additional_fields.title') %></h2>
+            <h2 class="fr-h2 fr-mb-3w fr-mt-8w" style="color: var(--background-action-high-blue-france);">2. <%= t('buyer.public_markets.additional_fields.title') %></h2>
             <div>
               <% optional_fields.each do |category, subcategories| %>
                 <div class="fr-card fr-mb-4w">

--- a/app/views/candidate/market_applications/company_identification.html.erb
+++ b/app/views/candidate/market_applications/company_identification.html.erb
@@ -9,7 +9,7 @@
       </p>
     </div>
 
-    <%= form_with model: @market_application, url: wizard_path, local: true, data: { turbo: false }, class: "fr-mb-4w" do |form| %>
+    <%= form_with model: @market_application, url: wizard_path, local: true, data: { turbo: false, controller: "input-validation" }, class: "fr-mb-4w" do |form| %>
       <div class="fr-mb-4w">
         <div class="fr-input-group<%= ' fr-input-group--error' if @market_application.errors[:siret].any? %>">
           <%= form.label :siret, "Veuillez saisir votre numéro de SIRET", class: "fr-label" %>
@@ -17,8 +17,7 @@
           <%= form.text_field :siret, 
                 class: "fr-input#{ ' fr-input--error' if @market_application.errors[:siret].any? }",
                 placeholder: "12345678901234",
-                maxlength: 14,
-                pattern: "\\d{14}" %>
+                data: { "input-validation-target": "input", action: "input->input-validation#validateInput" } %>
           <% if @market_application.errors[:siret].any? %>
             <p class="fr-error-text">
               <%= @market_application.errors[:siret].first %>
@@ -28,7 +27,7 @@
       </div>
 
       <div class="fr-mb-4w">
-        <%= form.submit "Continuer", class: "fr-btn fr-btn--lg" %>
+        <%= form.submit "Continuer", class: "fr-btn fr-btn--lg", data: { "input-validation-target": "submitButton" } %>
       </div>
     <% end %>
   </div>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -439,6 +439,10 @@ fr:
               cannot_be_alone: "le marché de défense ne peut pas être seul"
             market_type_codes:
               invalid_codes: "contient des codes invalides : %{codes}"
+        market_application:
+          attributes:
+            siret:
+              invalid: "doit être un numéro SIRET valide de 14 chiffres"
         editor:
           attributes:
             completion_webhook_url:

--- a/spec/requests/candidate/market_applications_spec.rb
+++ b/spec/requests/candidate/market_applications_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe 'Candidate::MarketApplications', type: :request do
           params: { market_application: { siret: wrong_format_siret } }
 
         expect(response).to have_http_status(:success)
-        # The actual error shows as i18n keys in the HTML
-        expect(response.body).to include('fr.activerecord.errors.models.market_application.attributes.siret.invalid')
+        # The actual error shows as translated message in the HTML
+        expect(response.body).to include('doit être un numéro SIRET valide de 14 chiffres')
 
         market_application.reload
         expect(market_application.siret).not_to eq(wrong_format_siret)
@@ -97,7 +97,7 @@ RSpec.describe 'Candidate::MarketApplications', type: :request do
           params: { market_application: { siret: wrong_length_siret } }
 
         expect(response).to have_http_status(:success)
-        expect(response.body).to include('fr.activerecord.errors.models.market_application.attributes.siret.invalid')
+        expect(response.body).to include('doit être un numéro SIRET valide de 14 chiffres')
 
         market_application.reload
         expect(market_application.siret).not_to eq(wrong_length_siret)


### PR DESCRIPTION
Added enable/disable javascript controller for managing submit button Removed native browser validation to have proper dsfr error display Added margin in summary sections.

Corrections des retours de  : 
* https://linear.app/pole-api/issue/FAS-30/page-daccueil-candidat-and-saisie-du-siret 
* https://linear.app/pole-api/issue/FAS-37/ajustement-uxui-du-formulaire-pour-une-meilleure-clarte-et-fluidite

@lordinatrice Si c'est ok pour toi je te laisse : 
* Merger
* Déployer l'app en sandbox (dans github Actions -> Development via https (sandbox) -> run worklow) 
* Passer les ticket en UX review 
* Prévenir natalia