### PR TITLE
use stepper as a partial

### DIFF
--- a/app/views/candidate/market_applications/_stepper.html.erb
+++ b/app/views/candidate/market_applications/_stepper.html.erb
@@ -1,0 +1,9 @@
+<div class="fr-grid-row fr-grid-row--gutters">
+  <div class="fr-col-12 fr-background-alt--blue-france fr-mb-3w">
+    <%= stepper(
+      current_step: step,
+      steps: @wizard_steps,
+      i18n_scope: 'candidate.market_applications.steps'
+    ) %>
+  </div>
+</div>

--- a/app/views/candidate/market_applications/economic_capacities.html.erb
+++ b/app/views/candidate/market_applications/economic_capacities.html.erb
@@ -1,14 +1,6 @@
 <% content_for :title, "#{@market_application.siret} - #{t('candidate.market_applications.steps.economic_capacities')}" %>
 
-<div class="fr-grid-row fr-grid-row--gutters">
-  <div class="fr-col-12">
-    <%= stepper(
-      current_step: step,
-      steps: @wizard_steps,
-      i18n_scope: 'candidate.market_applications.steps'
-    ) %>
-  </div>
-</div>
+<%= render "stepper", step: step, wizard_steps: @wizard_steps %>
 
 <% subcategories = t('candidate.market_applications.economic_capacities_data.subcategories') %>
 

--- a/app/views/candidate/market_applications/exclusion_criteria.html.erb
+++ b/app/views/candidate/market_applications/exclusion_criteria.html.erb
@@ -1,13 +1,5 @@
 <% content_for :title, "#{@market_application.siret} - #{t('candidate.market_applications.steps.exclusion_criteria')}" %>
 
-<div class="fr-grid-row fr-grid-row--gutters">
-  <div class="fr-col-12">
-    <%= stepper(
-      current_step: step,
-      steps: @wizard_steps,
-      i18n_scope: 'candidate.market_applications.steps'
-    ) %>
-  </div>
-</div>
+<%= render "stepper", step: step, wizard_steps: @wizard_steps %>
 
 <%= render("wizard_nav", submit_label: t('button.next_step')) %>

--- a/app/views/candidate/market_applications/market_and_company_information.html.erb
+++ b/app/views/candidate/market_applications/market_and_company_information.html.erb
@@ -1,14 +1,6 @@
 <% content_for :title, "#{@market_application.siret} - #{t('candidate.market_applications.steps.market_and_company_information')}" %>
 
-<div class="fr-grid-row fr-grid-row--gutters">
-  <div class="fr-col-12">
-    <%= stepper(
-      current_step: step,
-      steps: @wizard_steps,
-      i18n_scope: 'candidate.market_applications.steps'
-    ) %>
-  </div>
-</div>
+<%= render "stepper", step: step, wizard_steps: @wizard_steps %>
 
 <% subcategories = t('candidate.market_applications.market_and_company_information_data.subcategories') %>
 

--- a/app/views/candidate/market_applications/summary.html.erb
+++ b/app/views/candidate/market_applications/summary.html.erb
@@ -1,13 +1,5 @@
 <% content_for :title, "#{@market_application.siret} - #{t('candidate.market_applications.steps.summary')}" %>
 
-<div class="fr-grid-row fr-grid-row--gutters">
-  <div class="fr-col-12">
-    <%= stepper(
-      current_step: step,
-      steps: @wizard_steps,
-      i18n_scope: 'candidate.market_applications.steps'
-    ) %>
-  </div>
-</div>
+<%= render "stepper", step: step, wizard_steps: @wizard_steps %>
 
 <%= render "wizard_nav", submit_label: t('button.submit_summary') %>

--- a/app/views/candidate/market_applications/technical_capacities.html.erb
+++ b/app/views/candidate/market_applications/technical_capacities.html.erb
@@ -1,14 +1,6 @@
 <% content_for :title, "#{@market_application.siret} - #{t('candidate.market_applications.steps.technical_capacities.title')}" %>
 
-<div class="fr-grid-row fr-grid-row--gutters">
-  <div class="fr-col-12">
-    <%= stepper(
-      current_step: step,
-      steps: @wizard_steps,
-      i18n_scope: 'candidate.market_applications.steps'
-    ) %>
-  </div>
-</div>
+<%= render "stepper", step: step, wizard_steps: @wizard_steps %>
 
 <% subcategories = t('candidate.market_applications.technical_capacities_data.subcategories') %>
 


### PR DESCRIPTION
This pull request refactors the candidate market application views to use the stepper as a partial instead of rendering it inline

The main changes include:
- Extracting the stepper markup into a reusable partial
- Updating candidate views to render the stepper via the new partial