### PR TITLE
Feature/fas 79 generer une attestation vide de candidature pour poser la

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'turbo-rails'
 gem 'tzinfo-data', platforms: %i[windows jruby]
 gem 'wicked'
 gem 'interactor', '~> 3.2'
+gem 'wicked_pdf'
 
 group :development, :test do
   gem 'debug', platforms: %i[mri windows]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -465,6 +465,9 @@ GEM
     websocket-extensions (0.1.5)
     wicked (2.0.0)
       railties (>= 3.0.7)
+    wicked_pdf (2.8.2)
+      activesupport
+      ostruct
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.7.3)
@@ -515,6 +518,7 @@ DEPENDENCIES
   web-console
   webmock (~> 3.0)
   wicked
+  wicked_pdf
 
 RUBY VERSION
    ruby 3.4.5p51

--- a/app/assets/stylesheets/attestation_pdf.css
+++ b/app/assets/stylesheets/attestation_pdf.css
@@ -1,0 +1,69 @@
+/* Styles for PDF Attestation Template */
+
+body {
+  font-family: Arial, sans-serif;
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 40px;
+  color: #333;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 40px;
+  border-bottom: 2px solid #000091;
+  padding-bottom: 20px;
+}
+
+.title {
+  font-size: 24px;
+  font-weight: bold;
+  margin-bottom: 10px;
+  text-transform: uppercase;
+}
+
+.subtitle {
+  font-size: 18px;
+  font-weight: bold;
+  color: #666;
+}
+
+.content {
+  margin: 30px 0;
+}
+
+.field {
+  margin: 15px 0;
+  padding: 10px;
+  background-color: #f6f6f6;
+  border-left: 4px solid #000091;
+}
+
+.field-label {
+  font-weight: bold;
+  color: #000091;
+}
+
+.field-value {
+  margin-top: 5px;
+}
+
+.certification {
+  margin: 40px 0;
+  padding: 20px;
+  border: 1px solid #ddd;
+  background-color: #f9f9f9;
+  text-align: justify;
+}
+
+.footer {
+  margin-top: 50px;
+  text-align: right;
+  font-size: 10px;
+  font-style: italic;
+  color: #666;
+}
+
+.logo {
+  margin-bottom: 20px;
+}

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -14,7 +14,9 @@ class Api::V1::BaseController < ActionController::API
   private
 
   def current_editor
-    @current_editor ||= Editor.find_by(client_id: doorkeeper_token.application.uid)
+    return @current_editor if defined?(@current_editor)
+
+    @current_editor = Editor.find_by(client_id: doorkeeper_token.application.uid)
   end
 
   def doorkeeper_unauthorized_render_options(*)

--- a/app/controllers/candidate/market_applications_controller.rb
+++ b/app/controllers/candidate/market_applications_controller.rb
@@ -34,7 +34,11 @@ module Candidate
     def retry_sync
       @market_application.update!(sync_status: :sync_pending)
 
-      MarketApplicationWebhookJob.perform_later(@market_application.id)
+      MarketApplicationWebhookJob.perform_later(
+        @market_application.id,
+        request_host: request.host_with_port,
+        request_protocol: request.protocol
+      )
 
       redirect_to candidate_sync_status_path(@market_application.identifier),
         notice: t('candidate.market_application.sync_retry_initiated')
@@ -51,7 +55,11 @@ module Candidate
       result = CompleteMarketApplication.call(market_application: @market_application)
 
       if result.success?
-        MarketApplicationWebhookJob.perform_later(@market_application.id)
+        MarketApplicationWebhookJob.perform_later(
+          @market_application.id,
+          request_host: request.host_with_port,
+          request_protocol: request.protocol
+        )
         redirect_to candidate_sync_status_path(@market_application.identifier)
       else
         flash.now[:alert] = result.message

--- a/app/interactors/generate_attestation_pdf.rb
+++ b/app/interactors/generate_attestation_pdf.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class GenerateAttestationPdf < ApplicationInteractor
+  delegate :market_application, to: :context
+
+  def call
+    context.fail!(message: 'Attestation déjà générée') if market_application.attestation.attached?
+
+    generate_and_attach_pdf
+    context.attestation = market_application.attestation
+  end
+
+  private
+
+  def generate_and_attach_pdf
+    ActiveRecord::Base.transaction do
+      pdf_content = generate_pdf_content
+
+      market_application.attestation.attach(
+        io: StringIO.new(pdf_content),
+        filename:,
+        content_type: 'application/pdf'
+      )
+    end
+  rescue ActiveStorage::Error => e
+    context.fail!(message: "Erreur de stockage du fichier: #{e.message}")
+  rescue ActiveRecord::ActiveRecordError => e
+    context.fail!(message: "Erreur de base de données lors de l'attachement: #{e.message}")
+  rescue StandardError => e
+    context.fail!(message: "Erreur inattendue lors de la génération de l'attestation: #{e.message}")
+  end
+
+  def filename
+    "attestation_FT#{market_application.identifier}.pdf"
+  end
+
+  def generate_pdf_content
+    html_content = ApplicationController.render(
+      template: 'candidate/attestations/show',
+      formats: [:pdf],
+      layout: false,
+      locals: { market_application: }
+    )
+
+    WickedPdf.new.pdf_from_string(
+      html_content,
+      page_size: 'A4',
+      margin: {
+        top: 20,
+        bottom: 20,
+        left: 15,
+        right: 15
+      }
+    )
+  end
+end

--- a/app/interactors/mark_application_as_completed.rb
+++ b/app/interactors/mark_application_as_completed.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class MarkApplicationAsCompleted < ApplicationInteractor
+  delegate :market_application, to: :context
+
+  def call
+    context.fail!(message: 'Application already completed') if market_application.completed?
+
+    market_application.complete!
+    context.completed_at = market_application.completed_at
+  end
+end

--- a/app/jobs/market_application_webhook_job.rb
+++ b/app/jobs/market_application_webhook_job.rb
@@ -16,8 +16,22 @@ class MarketApplicationWebhookJob < WebhookJob
       timestamp: entity.completed_at.iso8601,
       market_identifier: entity.public_market.identifier,
       market_application: {
-        identifier: entity.identifier
+        identifier: entity.identifier,
+        siret: entity.siret,
+        attestation_url: attestation_url_for(entity)
       }
     }
+  end
+
+  def attestation_url_for(entity)
+    # Parse the base URL to extract host and port
+    uri = URI.parse(Rails.application.config.api_base_url)
+
+    Rails.application.routes.url_helpers.attestation_api_v1_market_application_url(
+      entity.identifier,
+      host: uri.host,
+      port: uri.port == uri.default_port ? nil : uri.port,
+      protocol: uri.scheme
+    )
   end
 end

--- a/app/jobs/market_application_webhook_job.rb
+++ b/app/jobs/market_application_webhook_job.rb
@@ -4,6 +4,12 @@
 class MarketApplicationWebhookJob < WebhookJob
   include WebhookSyncable
 
+  def perform(entity_id, request_host: nil, request_protocol: nil)
+    @request_host = request_host
+    @request_protocol = request_protocol
+    super(entity_id)
+  end
+
   private
 
   def find_entity(entity_id)
@@ -24,14 +30,10 @@ class MarketApplicationWebhookJob < WebhookJob
   end
 
   def attestation_url_for(entity)
-    # Parse the base URL to extract host and port
-    uri = URI.parse(Rails.application.config.api_base_url)
-
     Rails.application.routes.url_helpers.attestation_api_v1_market_application_url(
       entity.identifier,
-      host: uri.host,
-      port: uri.port == uri.default_port ? nil : uri.port,
-      protocol: uri.scheme
+      host: @request_host,
+      protocol: @request_protocol
     )
   end
 end

--- a/app/models/editor.rb
+++ b/app/models/editor.rb
@@ -20,7 +20,9 @@ class Editor < ApplicationRecord
   end
 
   def doorkeeper_application
-    @doorkeeper_application ||= CustomDoorkeeperApplication.find_by(uid: client_id)
+    return @doorkeeper_application if defined?(@doorkeeper_application)
+
+    @doorkeeper_application = CustomDoorkeeperApplication.find_by(uid: client_id)
   end
 
   def ensure_doorkeeper_application!

--- a/app/models/market_application.rb
+++ b/app/models/market_application.rb
@@ -7,6 +7,8 @@ class MarketApplication < ApplicationRecord
   belongs_to :public_market
   has_one :editor, through: :public_market
 
+  has_one_attached :attestation
+
   validates :identifier, presence: true, uniqueness: true
   validates :siret, format: { with: /\A\d{14}\z/ }, allow_blank: true
   validate :market_must_be_completed

--- a/app/organizers/complete_market_application.rb
+++ b/app/organizers/complete_market_application.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class CompleteMarketApplication < ApplicationOrganizer
+  organize MarkApplicationAsCompleted,
+    GenerateAttestationPdf
+end

--- a/app/views/candidate/attestations/show.pdf.erb
+++ b/app/views/candidate/attestations/show.pdf.erb
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <%= stylesheet_link_tag 'attestation_pdf', 'data-turbo-track': 'reload' %>
+</head>
+<body>
+  <div class="header">
+    <div class="logo">
+    </div>
+    <div class="title">Attestation de Candidature</div>
+    <div class="subtitle">Voie Rapide - Fast Track</div>
+  </div>
+
+  <div class="content">
+    <div class="field">
+      <div class="field-label">Identifiant de candidature</div>
+      <div class="field-value">FT<%= market_application.identifier %></div>
+    </div>
+
+    <% if market_application.siret.present? %>
+      <div class="field">
+        <div class="field-label">Numéro SIRET</div>
+        <div class="field-value"><%= market_application.siret %></div>
+      </div>
+    <% end %>
+
+    <div class="field">
+      <div class="field-label">Marché public</div>
+      <div class="field-value"><%= market_application.public_market.name %></div>
+    </div>
+
+    <div class="field">
+      <div class="field-label">Éditeur</div>
+      <div class="field-value"><%= market_application.editor.name %></div>
+    </div>
+
+    <div class="field">
+      <div class="field-label">Date de candidature</div>
+      <div class="field-value">
+        <%= market_application.completed_at&.strftime('%d/%m/%Y à %H:%M') %>
+      </div>
+    </div>
+  </div>
+
+  <div class="certification">
+    <p>
+      <strong>Certification :</strong>
+    </p>
+    <p>
+      Cette attestation certifie que la candidature référencée ci-dessus a été 
+      soumise avec succès dans le système Voie Rapide (Fast Track) à la date 
+      et heure indiquées.
+    </p>
+    <p>
+      Ce document constitue une preuve officielle de dépôt de candidature et 
+      peut être présenté aux autorités compétentes si nécessaire.
+    </p>
+  </div>
+
+  <div class="footer">
+    <p>
+      Document généré automatiquement le <%= Time.current.strftime('%d/%m/%Y à %H:%M') %><br>
+      Système Voie Rapide - République Française
+    </p>
+  </div>
+</body>
+</html>

--- a/app/views/candidate/sync_status/show.html.erb
+++ b/app/views/candidate/sync_status/show.html.erb
@@ -15,6 +15,11 @@
               Nous avons transmis automatiquement toutes les informations nécessaires à l’acheteur. Vous pouvez télécharger votre attestation de candidature qui vous servira comme preuve de dépôt.
             </p>
             <div class="fr-btns-group fr-btns-group--inline fr-mt-3w">
+              <% if @market_application.attestation.attached? %>
+                <%= link_to "Télécharger l'attestation", 
+                            rails_blob_path(@market_application.attestation, disposition: 'attachment'),
+                            class: 'fr-btn fr-btn--primary' %>
+              <% end %>
               <%= link_to "Retourner sur #{@market_application.editor.name}", 
                           @market_application.editor.redirect_url&.gsub('{market_identifier}', @market_application.identifier) || root_path,
                           class: 'fr-btn' %>
@@ -39,6 +44,11 @@
               <%= link_to "Contactez-nous", 
                           "mailto:support@voie-rapide.gouv.fr?subject=Erreur de synchronisation pour le marché #{@market_application.identifier}",
                           class: "fr-btn fr-btn--secondary" %>
+              <% if @market_application.attestation.attached? %>
+                <%= link_to "Télécharger l'attestation", 
+                            rails_blob_path(@market_application.attestation, disposition: 'attachment'),
+                            class: 'fr-btn fr-btn--primary' %>
+              <% end %>
             </div>
           </div>
         <% else %>

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Configure ActiveStorage URL expiration for attestation downloads
+# Default is 5 minutes, we extend to 48 hours for user convenience
+Rails.application.configure do
+  config.active_storage.urls_expire_in = 24.hours
+end

--- a/config/initializers/api_url_config.rb
+++ b/config/initializers/api_url_config.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  # API URL configuration for webhooks and external links
+  # This should be set via environment variables in production
+  config.api_base_url = ENV.fetch('API_BASE_URL') do
+    case Rails.env
+    when 'sandbox'
+      # Production should always have API_BASE_URL set
+      raise 'API_BASE_URL environment variable is required in production'
+    else
+      'http://localhost:3000'
+    end
+  end
+end

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+WickedPdf.config ||= {}
+
+if Rails.env.test?
+  # Mock wkhtmltopdf for tests
+  WickedPdf.config.merge!({
+    exe_path: '/bin/echo', # Use echo to mock PDF generation in tests
+    enable_local_file_access: true
+  })
+else
+  # Use the actual wkhtmltopdf installation
+  WickedPdf.config.merge!({
+    exe_path: '/usr/bin/wkhtmltopdf',
+    enable_local_file_access: true,
+    wkhtmltopdf: '/usr/bin/wkhtmltopdf'
+  })
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,11 @@ Rails.application.routes.draw do
       resources :public_markets, only: [:create] do
         resources :market_applications, only: [:create]
       end
+      resources :market_applications, only: [] do
+        member do
+          get :attestation
+        end
+      end
     end
   end
 

--- a/db/migrate/20250823090633_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250823090633_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_22_123114) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_23_090633) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -270,6 +298,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_22_123114) do
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "market_applications", "public_markets"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_22_123114) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_23_090633) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -270,6 +298,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_22_123114) do
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "market_applications", "public_markets"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"

--- a/fake_editor_app/lib/database.rb
+++ b/fake_editor_app/lib/database.rb
@@ -231,6 +231,11 @@ class MarketApplication < Sequel::Model(DB[:market_applications])
     respond_to?(:webhook_payload) && !webhook_payload.nil? && !webhook_payload.empty?
   end
   
+  def attestation_url
+    return nil unless has_webhook_data?
+    webhook_data.dig('market_application', 'attestation_url')
+  end
+  
   def data
     return {} if application_data.nil?
     JSON.parse(application_data)

--- a/fake_editor_app/lib/fast_track_client.rb
+++ b/fake_editor_app/lib/fast_track_client.rb
@@ -94,4 +94,25 @@ class FastTrackClient
 
     response.parsed_response
   end
+
+  def download_attestation(access_token, application_identifier)
+    response = self.class.get(
+      "#{@base_url}/api/v1/market_applications/#{application_identifier}/attestation",
+      headers: {
+        'Authorization' => "Bearer #{access_token}"
+      }
+    )
+
+    unless response.success?
+      error_details = response.parsed_response
+      error_msg = if error_details.is_a?(Hash) && error_details['error']
+                    "#{response.code} - #{error_details['error']}"
+                  else
+                    "#{response.code} - #{response.message}"
+                  end
+      raise "Attestation download failed: #{error_msg}"
+    end
+
+    response.body
+  end
 end

--- a/fake_editor_app/public/style.css
+++ b/fake_editor_app/public/style.css
@@ -182,6 +182,27 @@ body {
   background: #c82333;
 }
 
+.btn-disabled {
+  background: #6c757d;
+  color: white;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.btn-disabled:hover {
+  background: #6c757d;
+  color: white;
+}
+
+.btn-secondary {
+  background: #6c757d;
+  color: white;
+}
+
+.btn-secondary:hover {
+  background: #545b62;
+}
+
 .inline-form {
   display: inline-block;
 }

--- a/fake_editor_app/views/application_detail.erb
+++ b/fake_editor_app/views/application_detail.erb
@@ -54,6 +54,17 @@
          target="_blank" class="btn btn-primary">
         🔄 Reprendre la candidature
       </a>
+    <% else %>
+      <% if @application.attestation_url %>
+        <a href="/applications/<%= @application.identifier %>/download_attestation" 
+           class="btn btn-primary">
+          📄 Télécharger l'attestation
+        </a>
+      <% else %>
+        <span class="btn btn-disabled">
+          📄 Attestation non disponible
+        </span>
+      <% end %>
     <% end %>
     
     <a href="/markets/<%= @market.identifier %>" class="btn btn-secondary">

--- a/spec/features/candidate_attestation_download_spec.rb
+++ b/spec/features/candidate_attestation_download_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Candidate attestation download', type: :feature do
   let(:market_application) { create(:market_application, siret: nil) }
 
   scenario 'completing application generates attestation and shows secure download link' do
-    CompleteMarketApplication.call(market_application: market_application)
+    CompleteMarketApplication.call(market_application:)
 
     market_application.update!(sync_status: :sync_completed)
 

--- a/spec/features/candidate_attestation_download_spec.rb
+++ b/spec/features/candidate_attestation_download_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'Candidate attestation download', type: :feature do
+  before do
+    allow_any_instance_of(WickedPdf).to receive(:pdf_from_string).and_return('fake pdf content')
+  end
+  let(:market_application) { create(:market_application, siret: nil) }
+
+  scenario 'completing application generates attestation and shows secure download link' do
+    CompleteMarketApplication.call(market_application: market_application)
+
+    market_application.update!(sync_status: :sync_completed)
+
+    visit candidate_sync_status_path(market_application.identifier)
+
+    market_application.reload
+    expect(market_application.attestation).to be_attached
+
+    expect(page).to have_link('Télécharger l\'attestation')
+
+    download_link = find_link('Télécharger l\'attestation')[:href]
+    expect(download_link).to include('/rails/active_storage/blobs/redirect')
+    expect(download_link).to include('disposition=attachment')
+  end
+
+  scenario 'attestation not available before completion' do
+    visit candidate_sync_status_path(market_application.identifier)
+
+    expect(page).not_to have_link('Télécharger l\'attestation')
+  end
+end

--- a/spec/interactors/generate_attestation_pdf_spec.rb
+++ b/spec/interactors/generate_attestation_pdf_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GenerateAttestationPdf, type: :interactor do
+  before do
+    allow_any_instance_of(WickedPdf).to receive(:pdf_from_string).and_return('fake pdf content')
+  end
+  let(:market_application) { create(:market_application, siret: nil) }
+
+  describe '.call' do
+    subject { described_class.call(market_application: market_application) }
+
+    context 'when no attestation is attached' do
+      it 'succeeds' do
+        expect(subject).to be_success
+      end
+
+      it 'attaches an attestation PDF to the market application' do
+        subject
+        expect(market_application.attestation).to be_attached
+        expect(market_application.attestation.content_type).to eq('application/pdf')
+        expect(market_application.attestation.filename.to_s).to include("attestation_FT#{market_application.identifier}")
+      end
+
+      it 'sets the attestation in the context' do
+        result = subject
+        expect(result.attestation).to eq(market_application.attestation)
+      end
+    end
+
+    context 'when attestation is already attached' do
+      before { market_application.attestation.attach(io: StringIO.new('test'), filename: 'test.pdf', content_type: 'application/pdf') }
+
+      it 'fails' do
+        expect(subject).to be_failure
+      end
+
+      it 'provides error message' do
+        expect(subject.message).to eq('Attestation déjà générée')
+      end
+    end
+  end
+end

--- a/spec/interactors/generate_attestation_pdf_spec.rb
+++ b/spec/interactors/generate_attestation_pdf_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GenerateAttestationPdf, type: :interactor do
   let(:market_application) { create(:market_application, siret: nil) }
 
   describe '.call' do
-    subject { described_class.call(market_application: market_application) }
+    subject { described_class.call(market_application:) }
 
     context 'when no attestation is attached' do
       it 'succeeds' do

--- a/spec/interactors/mark_application_as_completed_spec.rb
+++ b/spec/interactors/mark_application_as_completed_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MarkApplicationAsCompleted, type: :interactor do
   let(:market_application) { create(:market_application, siret: nil) }
 
   describe '.call' do
-    subject { described_class.call(market_application: market_application) }
+    subject { described_class.call(market_application:) }
 
     context 'when market application is not completed' do
       it 'succeeds' do

--- a/spec/interactors/mark_application_as_completed_spec.rb
+++ b/spec/interactors/mark_application_as_completed_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MarkApplicationAsCompleted, type: :interactor do
+  let(:market_application) { create(:market_application, siret: nil) }
+
+  describe '.call' do
+    subject { described_class.call(market_application: market_application) }
+
+    context 'when market application is not completed' do
+      it 'succeeds' do
+        expect(subject).to be_success
+      end
+
+      it 'sets completed_at timestamp' do
+        expect { subject }
+          .to change { market_application.reload.completed_at }
+          .from(nil).to(be_within(1.second).of(Time.current))
+      end
+
+      it 'sets completed_at in context' do
+        result = subject
+        expect(result.completed_at).to be_within(1.second).of(Time.current)
+      end
+    end
+
+    context 'when market application is already completed' do
+      let(:market_application) { create(:market_application, siret: nil, completed_at: 1.hour.ago) }
+
+      it 'fails' do
+        expect(subject).to be_failure
+      end
+
+      it 'provides error message' do
+        expect(subject.message).to eq('Application already completed')
+      end
+    end
+  end
+end

--- a/spec/organizers/complete_market_application_spec.rb
+++ b/spec/organizers/complete_market_application_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CompleteMarketApplication, type: :organizer do
+  before do
+    allow_any_instance_of(WickedPdf).to receive(:pdf_from_string).and_return('fake pdf content')
+  end
+  let(:market_application) { create(:market_application, siret: nil) }
+
+  describe '.call' do
+    subject { described_class.call(market_application: market_application) }
+
+    context 'when all steps succeed' do
+      it 'succeeds' do
+        expect(subject).to be_success
+      end
+
+      it 'marks application as completed' do
+        expect { subject }
+          .to change { market_application.reload.completed_at }
+          .from(nil).to(be_present)
+      end
+
+      it 'generates attestation PDF' do
+        expect { subject }
+          .to change { market_application.reload.attestation.attached? }
+          .from(false).to(true)
+      end
+
+      it 'sets both completed_at and attestation in context' do
+        result = subject
+        expect(result.completed_at).to be_present
+        expect(result.attestation).to be_present
+      end
+    end
+
+    context 'when PDF generation fails' do
+      before do
+        allow_any_instance_of(GenerateAttestationPdf).to receive(:call) do |instance|
+          instance.context.fail!(message: 'PDF generation failed')
+        end
+      end
+
+      it 'fails' do
+        expect(subject).to be_failure
+      end
+
+      it 'does not attach attestation' do
+        subject
+        expect(market_application.reload.attestation).not_to be_attached
+      end
+
+      it 'provides error message' do
+        expect(subject.message).to eq('PDF generation failed')
+      end
+    end
+
+    context 'when application is already completed' do
+      let(:market_application) { create(:market_application, siret: nil, completed_at: 1.hour.ago) }
+
+      it 'fails' do
+        expect(subject).to be_failure
+      end
+
+      it 'provides error message' do
+        expect(subject.message).to eq('Application already completed')
+      end
+
+      it 'does not modify existing completed_at' do
+        original_time = market_application.completed_at
+        subject
+        expect(market_application.reload.completed_at).to eq(original_time)
+      end
+    end
+  end
+end

--- a/spec/organizers/complete_market_application_spec.rb
+++ b/spec/organizers/complete_market_application_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CompleteMarketApplication, type: :organizer do
   let(:market_application) { create(:market_application, siret: nil) }
 
   describe '.call' do
-    subject { described_class.call(market_application: market_application) }
+    subject { described_class.call(market_application:) }
 
     context 'when all steps succeed' do
       it 'succeeds' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,6 +66,11 @@ RSpec.configure do |config|
   # Configure Devise test helpers
   config.include Devise::Test::IntegrationHelpers, type: :request
 
+  # Configure ActiveJob test adapter
+  config.before(:each) do
+    ActiveJob::Base.queue_adapter = :test
+  end
+
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 

--- a/spec/requests/api/v1/market_applications/attestation_spec.rb
+++ b/spec/requests/api/v1/market_applications/attestation_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe 'GET /api/v1/market_applications/:id/attestation', type: :request
   end
 
   describe 'with valid OAuth token' do
-    let(:public_market) { create(:public_market, :completed, editor: editor) }
+    let(:public_market) { create(:public_market, :completed, editor:) }
     let(:market_application) { create(:market_application, siret: nil, public_market:) }
 
     before do
-      CompleteMarketApplication.call(market_application: market_application)
+      CompleteMarketApplication.call(market_application:)
     end
 
     it 'returns the attestation PDF' do
@@ -57,11 +57,11 @@ RSpec.describe 'GET /api/v1/market_applications/:id/attestation', type: :request
   end
 
   describe 'with different editor OAuth token' do
-    let(:public_market) { create(:public_market, :completed, editor: editor) }
+    let(:public_market) { create(:public_market, :completed, editor:) }
     let(:market_application) { create(:market_application, siret: nil, public_market:) }
 
     before do
-      CompleteMarketApplication.call(market_application: market_application)
+      CompleteMarketApplication.call(market_application:)
     end
 
     it 'returns not found (editor does not own this application)' do
@@ -74,7 +74,7 @@ RSpec.describe 'GET /api/v1/market_applications/:id/attestation', type: :request
   end
 
   describe 'without OAuth token' do
-    let(:public_market) { create(:public_market, :completed, editor: editor) }
+    let(:public_market) { create(:public_market, :completed, editor:) }
     let(:market_application) { create(:market_application, siret: nil, public_market:) }
 
     it 'returns unauthorized' do
@@ -86,7 +86,7 @@ RSpec.describe 'GET /api/v1/market_applications/:id/attestation', type: :request
   end
 
   describe 'with invalid OAuth token' do
-    let(:public_market) { create(:public_market, :completed, editor: editor) }
+    let(:public_market) { create(:public_market, :completed, editor:) }
     let(:market_application) { create(:market_application, siret: nil, public_market:) }
 
     it 'returns unauthorized' do

--- a/spec/requests/api/v1/market_applications/attestation_spec.rb
+++ b/spec/requests/api/v1/market_applications/attestation_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GET /api/v1/market_applications/:id/attestation', type: :request do
+  let(:editor) { create(:editor, :authorized_and_active) }
+  let(:other_editor) { create(:editor, :authorized_and_active) }
+
+  let(:access_token) { oauth_access_token_for(editor) }
+  let(:other_access_token) { oauth_access_token_for(other_editor) }
+
+  before do
+    allow_any_instance_of(WickedPdf).to receive(:pdf_from_string).and_return('fake pdf content')
+  end
+
+  describe 'with valid OAuth token' do
+    let(:public_market) { create(:public_market, :completed, editor: editor) }
+    let(:market_application) { create(:market_application, siret: nil, public_market:) }
+
+    before do
+      CompleteMarketApplication.call(market_application: market_application)
+    end
+
+    it 'returns the attestation PDF' do
+      get "/api/v1/market_applications/#{market_application.identifier}/attestation",
+        headers: { 'Authorization' => "Bearer #{access_token}" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to eq('application/pdf')
+      expect(response.headers['Content-Disposition']).to include('attachment')
+      expect(response.headers['Content-Disposition']).to include("attestation_FT#{market_application.identifier}.pdf")
+    end
+
+    context 'when application is not completed' do
+      let(:incomplete_application) { create(:market_application, siret: nil, public_market:, completed_at: nil) }
+
+      it 'returns unprocessable entity' do
+        get "/api/v1/market_applications/#{incomplete_application.identifier}/attestation",
+          headers: { 'Authorization' => "Bearer #{access_token}" }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body).to eq({ 'error' => 'Application not completed' })
+      end
+    end
+
+    context 'when attestation is not available' do
+      let(:completed_application) { create(:market_application, siret: nil, public_market:, completed_at: 1.hour.ago) }
+
+      it 'returns not found' do
+        get "/api/v1/market_applications/#{completed_application.identifier}/attestation",
+          headers: { 'Authorization' => "Bearer #{access_token}" }
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body).to eq({ 'error' => 'Attestation not available' })
+      end
+    end
+  end
+
+  describe 'with different editor OAuth token' do
+    let(:public_market) { create(:public_market, :completed, editor: editor) }
+    let(:market_application) { create(:market_application, siret: nil, public_market:) }
+
+    before do
+      CompleteMarketApplication.call(market_application: market_application)
+    end
+
+    it 'returns not found (editor does not own this application)' do
+      get "/api/v1/market_applications/#{market_application.identifier}/attestation",
+        headers: { 'Authorization' => "Bearer #{other_access_token}" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ 'error' => 'Market application not found' })
+    end
+  end
+
+  describe 'without OAuth token' do
+    let(:public_market) { create(:public_market, :completed, editor: editor) }
+    let(:market_application) { create(:market_application, siret: nil, public_market:) }
+
+    it 'returns unauthorized' do
+      get "/api/v1/market_applications/#{market_application.identifier}/attestation"
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body).to eq({ 'error' => 'Not authorized' })
+    end
+  end
+
+  describe 'with invalid OAuth token' do
+    let(:public_market) { create(:public_market, :completed, editor: editor) }
+    let(:market_application) { create(:market_application, siret: nil, public_market:) }
+
+    it 'returns unauthorized' do
+      get "/api/v1/market_applications/#{market_application.identifier}/attestation",
+        headers: { 'Authorization' => 'Bearer invalid_token' }
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body).to eq({ 'error' => 'Not authorized' })
+    end
+  end
+
+  describe 'with non-existent application' do
+    it 'returns not found' do
+      get '/api/v1/market_applications/nonexistent/attestation',
+        headers: { 'Authorization' => "Bearer #{access_token}" }
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq({ 'error' => 'Market application not found' })
+    end
+  end
+end

--- a/spec/requests/api/v1/market_applications_spec.rb
+++ b/spec/requests/api/v1/market_applications_spec.rb
@@ -3,15 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::MarketApplications', type: :request do
-  let(:editor) { create(:editor) }
-  let(:public_market) { create(:public_market, :completed, editor:) }
-  let(:access_token) do
-    editor.ensure_doorkeeper_application!
-    Doorkeeper::AccessToken.create!(
-      application: editor.doorkeeper_application,
-      scopes: 'api_access'
-    )
-  end
+  let(:editor) { create(:editor, :authorized_and_active) }
+  let(:public_market) { create(:public_market, :completed, editor: editor) }
+  let(:access_token) { oauth_access_token_for(editor) }
 
   describe 'POST /api/v1/public_markets/:public_market_id/market_applications' do
     let(:valid_siret) { '73282932000074' }
@@ -28,7 +22,7 @@ RSpec.describe 'Api::V1::MarketApplications', type: :request do
     it 'creates market application successfully' do
       post "/api/v1/public_markets/#{public_market.identifier}/market_applications",
         params: valid_params,
-        headers: { 'Authorization' => "Bearer #{access_token.token}" },
+        headers: { 'Authorization' => "Bearer #{access_token}" },
         as: :json
 
       expect(response).to have_http_status(:created)
@@ -42,7 +36,7 @@ RSpec.describe 'Api::V1::MarketApplications', type: :request do
       expect do
         post "/api/v1/public_markets/#{public_market.identifier}/market_applications",
           params: valid_params,
-          headers: { 'Authorization' => "Bearer #{access_token.token}" },
+          headers: { 'Authorization' => "Bearer #{access_token}" },
           as: :json
       end.to change(MarketApplication, :count).by(1)
 
@@ -54,7 +48,7 @@ RSpec.describe 'Api::V1::MarketApplications', type: :request do
     it 'returns error when public market not found' do
       post '/api/v1/public_markets/NONEXISTENT/market_applications',
         params: valid_params,
-        headers: { 'Authorization' => "Bearer #{access_token.token}" },
+        headers: { 'Authorization' => "Bearer #{access_token}" },
         as: :json
 
       expect(response).to have_http_status(:not_found)
@@ -68,7 +62,7 @@ RSpec.describe 'Api::V1::MarketApplications', type: :request do
 
       post "/api/v1/public_markets/#{other_market.identifier}/market_applications",
         params: valid_params,
-        headers: { 'Authorization' => "Bearer #{access_token.token}" },
+        headers: { 'Authorization' => "Bearer #{access_token}" },
         as: :json
 
       expect(response).to have_http_status(:not_found)
@@ -83,7 +77,7 @@ RSpec.describe 'Api::V1::MarketApplications', type: :request do
 
       post "/api/v1/public_markets/#{public_market.identifier}/market_applications",
         params: invalid_params,
-        headers: { 'Authorization' => "Bearer #{access_token.token}" },
+        headers: { 'Authorization' => "Bearer #{access_token}" },
         as: :json
 
       expect(response).to have_http_status(:unprocessable_content)
@@ -100,7 +94,7 @@ RSpec.describe 'Api::V1::MarketApplications', type: :request do
 
       post "/api/v1/public_markets/#{public_market.identifier}/market_applications",
         params: la_poste_params,
-        headers: { 'Authorization' => "Bearer #{access_token.token}" },
+        headers: { 'Authorization' => "Bearer #{access_token}" },
         as: :json
 
       expect(response).to have_http_status(:created)

--- a/spec/requests/api/v1/market_applications_spec.rb
+++ b/spec/requests/api/v1/market_applications_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Api::V1::MarketApplications', type: :request do
   let(:editor) { create(:editor, :authorized_and_active) }
-  let(:public_market) { create(:public_market, :completed, editor: editor) }
+  let(:public_market) { create(:public_market, :completed, editor:) }
   let(:access_token) { oauth_access_token_for(editor) }
 
   describe 'POST /api/v1/public_markets/:public_market_id/market_applications' do

--- a/spec/requests/api/v1/public_markets_spec.rb
+++ b/spec/requests/api/v1/public_markets_spec.rb
@@ -13,13 +13,7 @@ RSpec.describe 'API::V1::PublicMarkets', type: :request do
     )
   end
 
-  let(:access_token) do
-    editor.ensure_doorkeeper_application!
-    Doorkeeper::AccessToken.create!(
-      application: editor.doorkeeper_application,
-      scopes: 'api_access'
-    )
-  end
+  let(:access_token) { oauth_access_token_for(editor) }
 
   let!(:supplies_market_type) { create(:market_type, code: 'supplies') }
   let!(:defense_market_type) { create(:market_type, :defense) }
@@ -41,7 +35,7 @@ RSpec.describe 'API::V1::PublicMarkets', type: :request do
         post '/api/v1/public_markets',
           params: market_params.to_json,
           headers: {
-            'Authorization' => "Bearer #{access_token.token}",
+            'Authorization' => "Bearer #{access_token}",
             'Content-Type' => 'application/json'
           }
       end
@@ -147,7 +141,7 @@ RSpec.describe 'API::V1::PublicMarkets', type: :request do
         post '/api/v1/public_markets',
           params: invalid_params.to_json,
           headers: {
-            'Authorization' => "Bearer #{access_token.token}",
+            'Authorization' => "Bearer #{access_token}",
             'Content-Type' => 'application/json'
           }
       end
@@ -175,7 +169,7 @@ RSpec.describe 'API::V1::PublicMarkets', type: :request do
           post '/api/v1/public_markets',
             params: defense_params.to_json,
             headers: {
-              'Authorization' => "Bearer #{access_token.token}",
+              'Authorization' => "Bearer #{access_token}",
               'Content-Type' => 'application/json'
             }
         end
@@ -200,7 +194,7 @@ RSpec.describe 'API::V1::PublicMarkets', type: :request do
           post '/api/v1/public_markets',
             params: defense_alone_params.to_json,
             headers: {
-              'Authorization' => "Bearer #{access_token.token}",
+              'Authorization' => "Bearer #{access_token}",
               'Content-Type' => 'application/json'
             }
         end
@@ -217,7 +211,7 @@ RSpec.describe 'API::V1::PublicMarkets', type: :request do
           post '/api/v1/public_markets',
             params: market_params.to_json,
             headers: {
-              'Authorization' => "Bearer #{access_token.token}",
+              'Authorization' => "Bearer #{access_token}",
               'Content-Type' => 'application/json'
             }
         end

--- a/spec/requests/candidate/market_applications_spec.rb
+++ b/spec/requests/candidate/market_applications_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe 'Candidate::MarketApplications', type: :request do
     summary
   ].freeze
 
+  before do
+    allow_any_instance_of(WickedPdf).to receive(:pdf_from_string).and_return('fake pdf content')
+  end
+
   describe 'GET /candidate/market_applications/:identifier/:step' do
     STEPS.each_with_index do |step, idx|
       context 'when application is not completed' do

--- a/spec/requests/candidate/market_applications_spec.rb
+++ b/spec/requests/candidate/market_applications_spec.rb
@@ -178,7 +178,11 @@ RSpec.describe 'Candidate::MarketApplications', type: :request do
         end
 
         it 'enqueues webhook sync job' do
-          expect(MarketApplicationWebhookJob).to have_been_enqueued.with(market_application.id)
+          expect(MarketApplicationWebhookJob).to have_been_enqueued.with(
+            market_application.id,
+            request_host: 'www.example.com',
+            request_protocol: 'http://'
+          )
         end
       end
     end

--- a/spec/support/oauth_helpers.rb
+++ b/spec/support/oauth_helpers.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module OAuthHelpers
+  def oauth_access_token_for(editor, scope: 'api_access')
+    editor.ensure_doorkeeper_application!
+
+    post '/oauth/token', params: {
+      grant_type: 'client_credentials',
+      client_id: editor.client_id,
+      client_secret: editor.client_secret,
+      scope: scope
+    }
+
+    response.parsed_body['access_token']
+  end
+end
+
+RSpec.configure do |config|
+  config.include OAuthHelpers, type: :request
+end

--- a/spec/support/oauth_helpers.rb
+++ b/spec/support/oauth_helpers.rb
@@ -8,7 +8,7 @@ module OAuthHelpers
       grant_type: 'client_credentials',
       client_id: editor.client_id,
       client_secret: editor.client_secret,
-      scope: scope
+      scope:
     }
 
     response.parsed_body['access_token']


### PR DESCRIPTION
AMUSIERIEN SIE SICH.

Bon en vrai c'est pas une PR trop compliqué.

Elle soulève quand même des questions : 
- Pour le moment le stockage des fichiers va se faire avec active storage. C'est pas la solution finale choisie c'est la solution simple qui ne nécessite aucune installation sur l'environnement.
- La gem choisi utilise wkhtmltopdf il faudra l'installer sur les machines (mais c'est peut être déjà le cas ?)
- On pourrait générer l'attestation différement en faisant une route séparée qui affiche la page html (générée à la voléé du coup) et laisser la possibilité de le téléchargé. MAIS, on va avoir besoin d'inclure ce fichier dans le futur dossier zip (prochaine PR) du coup, je trouvais plus malin de faire comme cela
- La route d'accès pour les candidats est disponible durant 24h