### PR TITLE
Fix: Tests now succeeds to run in solo

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,6 +55,11 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
+  # Configure ActiveJob test adapter for job testing
+  config.before(:suite) do
+    ActiveJob::Base.queue_adapter = :test
+  end
+
   # Configure factory_bot
   config.include FactoryBot::Syntax::Methods
 


### PR DESCRIPTION
The tests files for the requests/buyer/public_markets and market_application would fail if they were run alone and working when the full suite was run.

This is now fix