### PR TITLE
Cleaning: adapt stepper helper for buyer and candidate

### DIFF
--- a/app/assets/stylesheets/utilities.css
+++ b/app/assets/stylesheets/utilities.css
@@ -53,6 +53,5 @@ footer.fr-footer {
 .stepper__separator {
   border: none;
   border-bottom: 2px solid var(--border-default-grey);
-  margin: 2rem 0 0;
   height: 0;
 }

--- a/app/assets/stylesheets/utilities.css
+++ b/app/assets/stylesheets/utilities.css
@@ -49,3 +49,10 @@ footer.fr-footer {
 .field-layout-badge {
   flex-shrink: 0;
 }
+
+.stepper__separator {
+  border: none;
+  border-bottom: 2px solid var(--border-default-grey);
+  margin: 2rem 0 0;
+  height: 0;
+}

--- a/app/controllers/buyer/public_markets_controller.rb
+++ b/app/controllers/buyer/public_markets_controller.rb
@@ -9,6 +9,7 @@ module Buyer
     before_action :find_public_market
     before_action :check_market_not_completed, except: [:retry_sync]
     before_action :initialize_presenter, except: [:retry_sync]
+    before_action :set_wizard_steps
 
     def show
       case step
@@ -42,6 +43,11 @@ module Buyer
     end
 
     private
+
+    def set_wizard_steps
+      # setup doesn't count as a step
+      @wizard_steps = steps - [:setup]
+    end
 
     def step_params
       case step

--- a/app/helpers/stepper_helper.rb
+++ b/app/helpers/stepper_helper.rb
@@ -12,7 +12,8 @@ module StepperHelper
         stepper_title(step_label, step_number, total_steps),
         stepper_steps_div(step_number, total_steps),
         stepper_details(current_step, steps, i18n_scope),
-        stepper_subtitle(i18n_scope, step)
+        stepper_subtitle(i18n_scope, step),
+        content_tag(:hr, nil, class: 'stepper__separator')
       ])
     end
   end
@@ -56,12 +57,16 @@ module StepperHelper
   end
 
   def stepper_subtitle(i18n_scope, step)
-    subtitle = t("#{i18n_scope}.#{step}", default: '')
+    subtitle_title = t("#{i18n_scope}.#{step}", default: '')
+    subtitle_text = t("#{i18n_scope}.#{step}.subtitle", default: 'Lorem ipsum...')
 
-    content_tag(
-      :h3,
-      subtitle,
-      class: 'fr-stepper__subtitle fr-mt-6w fr-text--bold"'
-    )
+    return if subtitle_title.blank? && subtitle_text.blank?
+
+    content_tag(:div, class: 'fr-stepper__subtitle-block') do
+      safe_join([
+        content_tag(:h3, subtitle_title, class: 'fr-stepper__subtitle fr-mt-6w fr-text--bold'),
+        content_tag(:p, subtitle_text, class: 'fr-stepper__subtext')
+      ])
+    end
   end
 end

--- a/app/helpers/stepper_helper.rb
+++ b/app/helpers/stepper_helper.rb
@@ -5,14 +5,15 @@ module StepperHelper
 
     step_number = steps.index(current_step) + 1
     total_steps = steps.size
-    step_label = t("#{i18n_scope}.#{current_step}")
+    step_label = t("#{i18n_scope}.steps.#{current_step}")
 
     content_tag(:div, class: 'fr-stepper') do
       safe_join([
         stepper_title(step_label, step_number, total_steps),
         stepper_steps_div(step_number, total_steps),
         stepper_details(current_step, steps, i18n_scope),
-        stepper_subtitle(i18n_scope, step),
+        content_tag(:div, nil, class: 'fr-mb-5w'),
+        stepper_subtitle(step, i18n_scope),
         content_tag(:hr, nil, class: 'stepper__separator')
       ])
     end
@@ -45,7 +46,7 @@ module StepperHelper
     content_tag(:p, class: 'fr-stepper__details') do
       next_step_index = steps.index(current_step) + 1
       if next_step_index < steps.size
-        next_step_label = t("#{i18n_scope}.#{steps[next_step_index]}")
+        next_step_label = t("#{i18n_scope}.steps.#{steps[next_step_index]}")
         safe_join([
           content_tag(:span, 'Étape suivante :', class: 'fr-text--bold'),
           " #{next_step_label}"
@@ -56,16 +57,16 @@ module StepperHelper
     end
   end
 
-  def stepper_subtitle(i18n_scope, step)
-    subtitle_title = t("#{i18n_scope}.#{step}", default: '')
-    subtitle_text = t("#{i18n_scope}.#{step}.subtitle", default: 'Lorem ipsum...')
+  def stepper_subtitle(step, i18n_scope)
+    subtitle_title = t("#{i18n_scope}.#{step}.title", default: '')
+    subtitle_text = t("#{i18n_scope}.#{step}.subtitle", default: '')
 
     return if subtitle_title.blank? && subtitle_text.blank?
 
-    content_tag(:div, class: 'fr-stepper__subtitle-block') do
+    content_tag(:div, class: 'fr-mb-5w') do
       safe_join([
-        content_tag(:h3, subtitle_title, class: 'fr-stepper__subtitle fr-mt-6w fr-text--bold'),
-        content_tag(:p, subtitle_text, class: 'fr-stepper__subtext')
+        content_tag(:h1, subtitle_title, class: 'fr-h1 fr-mb-1w'),
+        content_tag(:p, subtitle_text, class: 'fr-text--lg fr-mb-0')
       ])
     end
   end

--- a/app/helpers/stepper_helper.rb
+++ b/app/helpers/stepper_helper.rb
@@ -1,5 +1,5 @@
 module StepperHelper
-  def stepper(current_step:, steps:, i18n_scope:)
+  def stepper(current_step:, steps:, i18n_scope:, show_separator: false)
     current_step = current_step.to_sym
     return unless steps.include?(current_step)
 
@@ -14,7 +14,7 @@ module StepperHelper
         stepper_details(current_step, steps, i18n_scope),
         content_tag(:div, nil, class: 'fr-mb-5w'),
         stepper_subtitle(step, i18n_scope),
-        content_tag(:hr, nil, class: 'stepper__separator')
+        (content_tag(:hr, nil, class: 'stepper__separator') if show_separator)
       ])
     end
   end

--- a/app/views/buyer/public_markets/additional_fields.html.erb
+++ b/app/views/buyer/public_markets/additional_fields.html.erb
@@ -2,32 +2,16 @@
 
 <div class="fr-grid-row fr-grid-row--gutters">
   <div class="fr-col-12">
-    <div class="fr-stepper">
-      <h2 class="fr-stepper__title">
-        <%= t('buyer.public_markets.steps.additional_fields') %>
-        <span class="fr-stepper__state">Étape 2 sur 3</span>
-      </h2>
-      <div class="fr-stepper__steps" data-fr-current-step="2" data-fr-steps="3">
-        <div class="fr-stepper__step">
-          <p class="fr-stepper__details">
-            <span class="fr-text--bold">Étape suivante :</span> <%= t('buyer.public_markets.steps.summary') %>
-          </p>
-        </div>
-      </div>
-    </div>
+    <%= stepper(
+      current_step: step,
+      steps: @wizard_steps,
+      i18n_scope: 'buyer.public_markets'
+    ) %>
   </div>
 </div>
 
 <div class="fr-grid-row fr-grid-row--gutters fr-mt-4w">
   <div class="fr-col-12">
-    <div class="fr-mb-5w">
-      <h1 class="fr-h1 fr-mb-1w"><%= t('buyer.public_markets.additional_fields.title') %></h1>
-      <p class="fr-text--lg fr-mb-0">
-        <%= t('buyer.public_markets.additional_fields.subtitle') %>
-      </p>
-    </div>
-
-
     <div data-controller="additional-fields">
       <div class="fr-mb-4w fr-border-default--grey">
         <div class="fr-p-4w">
@@ -59,9 +43,9 @@
           <% @optional_fields.each_with_index do |(category, subcategories), index| %>
             <%= render 'category_accordion', category: category, index: index, id_prefix: 'accordion-optional' do %>
               <% subcategories.each_with_index do |(subcategory, fields), subcat_index| %>
-                <%= render 'subcategory_section', 
-                      subcategory: subcategory, 
-                      subcategories: subcategories, 
+                <%= render 'subcategory_section',
+                      subcategory: subcategory,
+                      subcategories: subcategories,
                       is_last: (subcat_index == subcategories.size - 1) do %>
                   <div class="fr-fieldset__content">
                     <% fields.each do |field_key| %>
@@ -81,8 +65,8 @@
           <%= link_to previous_wizard_path, class: "fr-btn fr-btn--secondary" do %>
             Précédent
           <% end %>
-          <%= form.submit "Suivant", 
-              class: "fr-btn fr-btn--lg", 
+          <%= form.submit "Suivant",
+              class: "fr-btn fr-btn--lg",
               data: { additional_fields_target: "submitButton" },
               disabled: true,
               title: "Suivant" %>

--- a/app/views/buyer/public_markets/required_fields.html.erb
+++ b/app/views/buyer/public_markets/required_fields.html.erb
@@ -2,55 +2,40 @@
 
 <div class="fr-grid-row fr-grid-row--gutters">
   <div class="fr-col-12">
-    <div class="fr-stepper">
-      <h2 class="fr-stepper__title">
-        <%= t('buyer.public_markets.steps.required_fields') %>
-        <span class="fr-stepper__state">Étape 1 sur 3</span>
-      </h2>
-      <div class="fr-stepper__steps" data-fr-current-step="1" data-fr-steps="3">
-        <div class="fr-stepper__step">
-          <p class="fr-stepper__details">
-            <span class="fr-text--bold">Étape suivante :</span> <%= t('buyer.public_markets.steps.additional_fields') %>
-          </p>
-        </div>
-      </div>
-    </div>
+      <%= stepper(
+      current_step: step,
+      steps: @wizard_steps,
+      i18n_scope: 'buyer.public_markets'
+    ) %>
   </div>
 </div>
 
 <div class="fr-grid-row fr-grid-row--gutters fr-mt-4w">
   <div class="fr-col-12">
-    <div class="fr-mb-5w">
-      <h1 class="fr-h1 fr-mb-1w"><%= t('buyer.public_markets.required_fields.title') %></h1>
-      <p class="fr-text--lg fr-mb-0">
-        <%= t('buyer.public_markets.required_fields.subtitle') %>
-      </p>
-    </div>
-
-      <div class="fr-accordions-group fr-mt-4w">
-        <% @required_fields.each_with_index do |(category, subcategories), index| %>
-          <%= render 'category_accordion', category: category, index: index, id_prefix: 'accordion-required' do %>
-            <% subcategories.each_with_index do |(subcategory, fields), subcat_index| %>
-              <%= render 'subcategory_section', 
-                    subcategory: subcategory, 
-                    subcategories: subcategories, 
-                    is_last: (subcat_index == subcategories.size - 1) do %>
-                <ul class="fr-list">
-                  <% fields.each do |field_key| %>
-                    <% field = @presenter.field_by_key(field_key) %>
-                    <%= render 'field_display', 
-                          field_key: field_key, 
-                          field: field, 
-                          html_tag: :li, 
-                          wrapper_classes: 'fr-list__item' %>
-                  <% end %>
-                </ul>
-              <% end %>
+    <div class="fr-accordions-group fr-mt-4w">
+      <% @required_fields.each_with_index do |(category, subcategories), index| %>
+        <%= render 'category_accordion', category: category, index: index, id_prefix: 'accordion-required' do %>
+          <% subcategories.each_with_index do |(subcategory, fields), subcat_index| %>
+            <%= render 'subcategory_section',
+                  subcategory: subcategory,
+                  subcategories: subcategories,
+                  is_last: (subcat_index == subcategories.size - 1) do %>
+              <ul class="fr-list">
+                <% fields.each do |field_key| %>
+                  <% field = @presenter.field_by_key(field_key) %>
+                  <%= render 'field_display',
+                        field_key: field_key,
+                        field: field,
+                        html_tag: :li,
+                        wrapper_classes: 'fr-list__item' %>
+                <% end %>
+              </ul>
             <% end %>
           <% end %>
         <% end %>
-      </div>
+      <% end %>
     </div>
+  </div>
 
     <div class="fr-col-12">
       <div class="fr-mb-4w">

--- a/app/views/buyer/public_markets/summary.html.erb
+++ b/app/views/buyer/public_markets/summary.html.erb
@@ -2,26 +2,16 @@
 
 <div class="fr-grid-row fr-grid-row--gutters">
   <div class="fr-col-12">
-    <div class="fr-stepper">
-      <h2 class="fr-stepper__title">
-        <%= t('buyer.public_markets.steps.summary') %>
-        <span class="fr-stepper__state">Étape 3 sur 3</span>
-      </h2>
-      <div class="fr-stepper__steps" data-fr-current-step="3" data-fr-steps="3">
-      </div>
-    </div>
+    <%= stepper(
+      current_step: step,
+      steps: @wizard_steps,
+      i18n_scope: 'buyer.public_markets'
+    ) %>
   </div>
 </div>
 
 <div class="fr-grid-row fr-grid-row--center">
   <div class="fr-col-12">
-    <div class="fr-mb-5w">
-      <h1 class="fr-h1 fr-mb-1w">Synthèse des paramètres de la candidature</h1>
-      <p class="fr-text--lg fr-mb-0">
-        Vérifiez les paramètres de votre marché avant de finaliser la configuration.
-      </p>
-    </div>
-
     <div class="fr-mb-4w">
       <div class="fr-card fr-mb-4w">
         <div class="fr-card__header">

--- a/app/views/candidate/market_applications/_stepper.html.erb
+++ b/app/views/candidate/market_applications/_stepper.html.erb
@@ -3,7 +3,8 @@
     <%= stepper(
       current_step: step,
       steps: @wizard_steps,
-      i18n_scope: 'candidate.market_applications'
+      i18n_scope: 'candidate.market_applications',
+      show_separator: true
     ) %>
   </div>
 </div>

--- a/app/views/candidate/market_applications/_stepper.html.erb
+++ b/app/views/candidate/market_applications/_stepper.html.erb
@@ -1,5 +1,5 @@
 <div class="fr-grid-row fr-grid-row--gutters">
-  <div class="fr-col-12 fr-background-alt--blue-france fr-mb-3w">
+  <div class="fr-col-12 fr-mb-3w">
     <%= stepper(
       current_step: step,
       steps: @wizard_steps,

--- a/app/views/candidate/market_applications/_stepper.html.erb
+++ b/app/views/candidate/market_applications/_stepper.html.erb
@@ -3,7 +3,7 @@
     <%= stepper(
       current_step: step,
       steps: @wizard_steps,
-      i18n_scope: 'candidate.market_applications.steps'
+      i18n_scope: 'candidate.market_applications'
     ) %>
   </div>
 </div>

--- a/app/views/candidate/market_applications/economic_capacities.html.erb
+++ b/app/views/candidate/market_applications/economic_capacities.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "stepper", step: step, wizard_steps: @wizard_steps %>
 
-<% subcategories = t('candidate.market_applications.economic_capacities_data.subcategories') %>
+<% subcategories = t('candidate.market_applications.economic_capacities.subcategories') %>
 
 <%= render "sidemenu_subcategories", subcategories: subcategories %>
 

--- a/app/views/candidate/market_applications/market_and_company_information.html.erb
+++ b/app/views/candidate/market_applications/market_and_company_information.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "stepper", step: step, wizard_steps: @wizard_steps %>
 
-<% subcategories = t('candidate.market_applications.market_and_company_information_data.subcategories') %>
+<% subcategories = t('candidate.market_applications.market_and_company_information.subcategories') %>
 
 <%= render "sidemenu_subcategories", subcategories: subcategories %>
 

--- a/app/views/candidate/market_applications/technical_capacities.html.erb
+++ b/app/views/candidate/market_applications/technical_capacities.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "stepper", step: step, wizard_steps: @wizard_steps %>
 
-<% subcategories = t('candidate.market_applications.technical_capacities_data.subcategories') %>
+<% subcategories = t('candidate.market_applications.technical_capacities.subcategories') %>
 
 <%= render "sidemenu_subcategories", subcategories: subcategories %>
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -123,7 +123,7 @@ fr:
       sync_retry_initiated: "La synchronisation a été relancée."
       steps:
         setup: "Configuration initiale"
-        required_fields: "Vérification des informations réglementaires et obligagtoires"
+        required_fields: "Vérification des informations réglementaires et obligatoires"
         additional_fields: "Sélection des informations non réglementaires"
         summary: "Synthèse"
       required_fields:
@@ -137,6 +137,9 @@ fr:
         question: "Je veux demander des informations et documents complémentaires au candidat"
         yes_option: "Oui"
         no_option: "Non"
+      summary:
+        title: "Synthèse des paramètres de la candidature"
+        subtitle: "Vérifiez les paramètres de votre marché avant de finaliser la configuration."
       sync:
         loading: "Synchronisation en cours..."
         processing:
@@ -162,24 +165,35 @@ fr:
         technical_capacities: "Les capacités techniques et professionnelles"
         summary: "Synthèse de votre candidature"
 
-      market_and_company_information_data:
+      market_and_company_information:
+        title: "Les informations du marché et de votre entreprise"
+        subtitle: "Lorem ipsum..."
         subcategories:
           market_information: "Informations du marché"
           company_information: "Informations de votre entreprise"
           contact_information: "Informations de contact"
-
-      economic_capacities_data:
+      exclusion_criteria:
+        title: "Les motifs d'exclusion"
+        subtitle: "Lorem ipsum..."
+      economic_capacities:
+        title: "Les capacités économiques et financières"
+        subtitle: "Lorem ipsum..."
         subcategories:
           annual_turnover: "Chiffre d'affaires"
           financial_statements: "Bilans"
           professional_risk_insurance: "Banque et assurance"
-      technical_capacities_data:
+      technical_capacities:
+        title: "Les capacités techniques et professionnelles"
+        subtitle: "Lorem ipsum..."
         subcategories:
               workforce: "Les effectifs"
               professional_certificates: "Les certificats"
               achievements: "Les réalisations"
               equipment_quality: "Outillage, matériel"
               quality_environment: "Assurance et qualité"
+      summary:
+        title: "Synthèse de votre candidature"
+        subtitle: "Lorem ipsum"
 
   admin:
     editors:

--- a/features/buyer_flow.feature
+++ b/features/buyer_flow.feature
@@ -20,16 +20,16 @@ Feature: Buyer Configuration Flow
     And I should see "Fourniture de matériel informatique"
     And I should see "Lot 1 - Ordinateurs portables"
     And I should see "Cochez cette case uniquement si votre marché concerne la défense ou la sécurité"
-    
+
     When I click on "Débuter l'activation de"
     Then I should be on the required documents page
-    And I should see "Vérification des informations réglementaires et obligagtoires"
+    And I should see "Vérification des informations réglementaires et obligatoires"
     And I should see "Les documents et informations réglementaires et obligatoires"
     And I should see "Test: Identité de l'entreprise"
     And I should see "Test: Motifs d'exclusion sociaux"
     And I should see a "Précédent" button
     And I should see a button "Suivant"
-    
+
     When I click on "Suivant"
     Then I should be on the optional documents page
     And I should see "Sélection des informations non réglementaires"
@@ -38,7 +38,7 @@ Feature: Buyer Configuration Flow
     And I should see "Test: Motifs d'exclusion à l'appréciation"
     And I should see a "Précédent" button
     And I should see a button "Suivant"
-    
+
     When I click on "Suivant"
     Then I should be on the summary page
     And I should see "Synthèse des paramètres de la candidature"
@@ -51,11 +51,11 @@ Feature: Buyer Configuration Flow
     When I go back to optional documents page
     Then I should be on the optional documents page
     And I should see "Sélection des informations non réglementaires"
-    
+
     When I click on "Précédent"
     Then I should be on the required documents page
-    And I should see "Vérification des informations réglementaires et obligagtoires"
-    
+    And I should see "Vérification des informations réglementaires et obligatoires"
+
     When I click on "Précédent"
     Then I should be on the setup page
     And I should see "Bienvenue,"
@@ -65,13 +65,13 @@ Feature: Buyer Configuration Flow
     Then I should see "Fourniture de matériel informatique"
     And I should see "Lot 1 - Ordinateurs portables"
     And I should see "Fournitures"
-    
+
     When I navigate to required documents page
     Then I should be on the required documents page
-    
+
     When I navigate to optional documents page
     Then I should be on the optional documents page
-    
+
     When I navigate to summary page
     Then I should see "Fourniture de matériel informatique"
     And I should see "Lot 1 - Ordinateurs portables"
@@ -79,9 +79,9 @@ Feature: Buyer Configuration Flow
 
   Scenario: Stepper indique correctement l'étape courante
     When I visit the required documents page for my public market
-    Then I should see "Vérification des informations réglementaires et obligagtoires"
+    Then I should see "Vérification des informations réglementaires et obligatoires"
     And the stepper should indicate step 1 as current
-    
+
     When I navigate to optional documents page
     Then I should see "Sélection des informations non réglementaires"
     And the stepper should indicate step 2 as current
@@ -89,15 +89,15 @@ Feature: Buyer Configuration Flow
   Scenario: Navigation directe vers différentes étapes
     When I visit the setup page for my public market
     Then I should be on the setup page
-    
+
     When I visit the required documents page for my public market
     Then I should be on the required documents page
     And I should see "Les documents et informations réglementaires et obligatoires"
-    
+
     When I visit the optional documents page for my public market
     Then I should be on the optional documents page
     And I should see "Les documents et informations demandés à titre non réglementaire"
-    
+
     When I visit the summary page for my public market
     Then I should be on the summary page
     And I should see "Synthèse des paramètres de la candidature"

--- a/features/step_definitions/buyer_flow_steps.rb
+++ b/features/step_definitions/buyer_flow_steps.rb
@@ -107,7 +107,7 @@ Then('the stepper should indicate step {int} as current') do |step_number|
 
   case step_number
   when 1
-    expect(page).to have_content('Vérification des informations réglementaires et obligagtoires')
+    expect(page).to have_content('Vérification des informations réglementaires et obligatoires')
     expect(page).to have_content('Étape 1 sur 3')
     expect(page).to have_css('.fr-stepper__steps[data-fr-current-step="1"]')
   when 2


### PR DESCRIPTION
This pull request refactors and improves the stepper component used in the buyer and candidate market application flows, making the UI more consistent and leveraging i18n for step titles and subtitles. It introduces a more flexible and maintainable stepper helper, updates translations for better clarity and structure, and cleans up the views to use the new helper.

**Stepper component refactor and improvements:**

* Refactored the `stepper` helper in `stepper_helper.rb` to use i18n keys for step titles and subtitles, and updated the structure to display both a title and subtitle per step, including a new horizontal separator for better visual separation
* Remove blue background
* Updated all buyer and candidate market application step views

* Added a `set_wizard_steps` before_action in `PublicMarketsController` to exclude the setup step from the stepper, ensuring the stepper accurately reflects the user's progress.

**Translation and i18n improvements:**

* Fixed a typo in the French translation for "required_fields" and restructured the `fr.yml` locale file to provide titles and subtitles for each step
* Updated candidate market application views to use the new translation structure for subcategories and step titles