### PR TITLE
Fix/improve file attachable for deletion

### DIFF
--- a/app/models/concerns/market_attribute_response/file_attachable.rb
+++ b/app/models/concerns/market_attribute_response/file_attachable.rb
@@ -35,6 +35,12 @@ module MarketAttributeResponse::FileAttachable
     end
   end
 
+  class_methods do
+    def file_attachable?
+      true
+    end
+  end
+
   private
 
   def validate_attached_files

--- a/app/models/market_application.rb
+++ b/app/models/market_application.rb
@@ -23,7 +23,7 @@ class MarketApplication < ApplicationRecord
 
   def find_authorized_document(attachment_id)
     market_attribute_responses
-      .where(type: MarketAttributeResponse.file_attachable_types)
+      .select { |r| r.class.file_attachable? }
       .flat_map(&:documents)
       .find { |doc| doc.id.to_s == attachment_id.to_s }
   end

--- a/app/models/market_attribute_response.rb
+++ b/app/models/market_attribute_response.rb
@@ -24,19 +24,12 @@ class MarketAttributeResponse < ApplicationRecord
     'inline_url_input' => 'InlineUrlInput'
   }.freeze
 
-  FILE_ATTACHABLE_TYPES = %w[
-    FileUpload
-    InlineFileUpload
-    FileOrTextarea
-    CheckboxWithDocument
-  ].freeze
-
   validates :type, presence: true, inclusion: { in: INPUT_TYPE_MAP.values }
 
   before_validation :set_type_from_market_attribute, on: :create
 
-  def self.file_attachable_types
-    FILE_ATTACHABLE_TYPES
+  def self.file_attachable?
+    false
   end
 
   def self.find_sti_class(type_name)

--- a/app/views/candidate/market_applications/market_attribute_responses/_echantillon_fields.html.erb
+++ b/app/views/candidate/market_applications/market_attribute_responses/_echantillon_fields.html.erb
@@ -40,19 +40,17 @@
             <% if index != 'NEW_RECORD' %>
               <% fichiers = market_attribute_response.echantillon_fichiers(index) %>
               <% if fichiers.any? %>
-                <div class="fr-mt-1w">
-                  <strong class="fr-text--sm">Fichiers actuels :</strong>
-                  <ul class="fr-text--sm">
+                <div class="fr-mt-1w fr-text--sm">
+                  <strong>Fichiers actuels :</strong>
                     <% fichiers.each do |fichier| %>
-                      <li>
+                      <div>
                         <span class="fr-icon--sm fr-icon-file-fill" aria-hidden="true"></span>
                         <%= link_to fichier.filename.to_s,
                                     url_for(fichier),
                                     target: "_blank", rel: "noopener" %>
                         (<%= number_to_human_size(fichier.byte_size) %>)
-                      </li>
+                      </div>
                     <% end %>
-                  </ul>
                 </div>
               <% end %>
             <% end %>


### PR DESCRIPTION
This replaces the need for a static `FILE_ATTACHABLE_TYPES` list by dynamically checking each response’s class for the `file_attachable?` method

This makes the code more robust and maintainable:

- No need to update a constant when adding new file-attachable types
- Each response class declares if it supports file attachments
- Reduces risk of bugs due to outdated or forgotten type lists

In summary:
The method now relies on class behavior instead of a hardcoded list, making it easier to extend and less error-prone.